### PR TITLE
Fix formatting of action in jail that was causing a bug

### DIFF
--- a/spec/defines/fail2ban_jail_spec.rb
+++ b/spec/defines/fail2ban_jail_spec.rb
@@ -4,18 +4,66 @@ describe 'fail2ban::jail' do
 
   let(:title) { 'fail2ban::jail' }
   let(:node) { 'rspec.example42.com' }
-  let(:facts) { { :ipaddress => '10.42.42.42', :jails_file => '/etc/fail2ban/jail.local', :concat_basedir => '/var/lib/puppet/concat'} }
+  let(:facts) do
+    {
+      :ipaddress      => '10.42.42.42',
+      :jails_file     => '/etc/fail2ban/jail.local',
+      :concat_basedir => '/var/lib/puppet/concat'
+    }
+  end
 
-  describe 'Test basic jail.local is created' do
-    let(:params) { { :name     => 'sample1',
-                     :port     => '42',
-                     :logpath  => '/path/to/somelog',
-                     :enable   => true,
-                     :findtime => '9000', } }
+  describe 'Test jail.local is created with no options' do
+    let(:params) do
+      {
+        :name => 'sample1',
+      }
+    end
+    let(:expected) do
+"##################
+[fail2ban::jail]
+enabled  = true
+filter   = fail2ban::jail
+
+"
+    end
 
     it { should include_class('concat::setup') }
-#    it { should contain_concat__fragment('fail2ban_jail_sample1').with_target('/etc/fail2ban/jail.local').with_content(/*port     = 42
-#logpath  = \/path\/to\/somelog*/) }
-    it { should contain_concat__fragment('fail2ban_jail_sample1').with_target('/etc/fail2ban/jail.local').with_content("##################\n[fail2ban::jail]\nenabled  = true\nfilter   = fail2ban::jail\nport     = 42\nlogpath  = /path/to/somelog\nfindtime = 9000\n\n") }
+    it { should contain_concat__fragment('fail2ban_jail_sample1').with_target('/etc/fail2ban/jail.local').with_content(expected) }
+  end
+
+  describe 'Test jail.local is created with all options' do
+    let(:params) do
+      {
+        :name     => 'sample1',
+        :port     => ['42', '43'],
+        :logpath  => '/path/to/somelog',
+        :enable   => true,
+        :findtime => '9000',
+        :maxretry => '5',
+        :bantime  => '3600',
+        :action   => [
+          'iptables[name=SSH, port=ssh, protocol=tcp]',
+          'mail-whois[name=SSH, dest=yourmail@mail.com]',
+        ],
+      }
+    end
+    let(:expected) do
+"##################
+[fail2ban::jail]
+enabled  = true
+filter   = fail2ban::jail
+port     = 42,43
+action   = iptables[name=SSH, port=ssh, protocol=tcp]
+	mail-whois[name=SSH, dest=yourmail@mail.com]
+logpath  = /path/to/somelog
+maxretry = 5
+bantime  = 3600
+findtime = 9000
+
+"
+    end
+
+    it { should include_class('concat::setup') }
+    it { should contain_concat__fragment('fail2ban_jail_sample1').with_target('/etc/fail2ban/jail.local').with_content(expected) }
   end
 end

--- a/templates/concat/jail.local-stanza.erb
+++ b/templates/concat/jail.local-stanza.erb
@@ -8,9 +8,7 @@ filter   = <%= @real_filter %>
 port     = <%= @array_port * ',' %>
 <% end -%>
 <% if @array_action != [] -%>
-action   = <% @array_action.each do |a| -%>
-          <%= a %>
-          <% end -%>
+action   = <%= @array_action.join("\n\t") %>
 <% end -%>
 <% if @real_logpath != '' -%>
 logpath  = <%= @real_logpath %>


### PR DESCRIPTION
This is to fix a bug in the jail.local-stanza template where if `action` is provided the formatting of the erb tags caused an extra indentation to be applied to the next line (e.g. `logpath`), resulting in a parse error from fail2ban.
