### PR TITLE
Refactor to use osfamily instead of operatingsystem

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,49 +16,49 @@ class fail2ban::params {
 
   ### Application related parameters
 
-  $package = $::operatingsystem ? {
+  $package = $::osfamily ? {
     default => 'fail2ban',
   }
 
-  $service = $::operatingsystem ? {
+  $service = $::osfamily ? {
     default => 'fail2ban',
   }
 
-  $service_status = $::operatingsystem ? {
+  $service_status = $::osfamily ? {
     default => true,
   }
 
-  $process = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/                           => 'fail2ban-server',
-    /(?i:RedHat|Centos|Scientific|Fedora|OracleLinux)/  => 'fail2ban-server',
-    default                                             => 'fail2ban',
+  $process = $::osfamily ? {
+    'Debian' => 'fail2ban-server',
+    'RedHat' => 'fail2ban-server',
+    default  => 'fail2ban',
   }
 
-  $process_args = $::operatingsystem ? {
+  $process_args = $::osfamily ? {
     default => '',
   }
 
-  $process_user = $::operatingsystem ? {
+  $process_user = $::osfamily ? {
     default => 'fail2ban',
   }
 
-  $config_dir = $::operatingsystem ? {
+  $config_dir = $::osfamily ? {
     default => '/etc/fail2ban',
   }
 
-  $config_file = $::operatingsystem ? {
+  $config_file = $::osfamily ? {
     default => '/etc/fail2ban/fail2ban.local',
   }
 
-  $config_file_mode = $::operatingsystem ? {
+  $config_file_mode = $::osfamily ? {
     default => '0644',
   }
 
-  $config_file_owner = $::operatingsystem ? {
+  $config_file_owner = $::osfamily ? {
     default => 'root',
   }
 
-  $config_file_group = $::operatingsystem ? {
+  $config_file_group = $::osfamily ? {
     default => 'root',
   }
 
@@ -69,41 +69,41 @@ class fail2ban::params {
   #            fail2ban::jail define
   $jails_config = ''
 
-  $jails_file = $::operatingsystem ? {
+  $jails_file = $::osfamily ? {
     default => '/etc/fail2ban/jail.local',
   }
 
-  $jails_file_mode = $::operatingsystem ? {
+  $jails_file_mode = $::osfamily ? {
     default => '0644',
   }
 
-  $jails_file_owner = $::operatingsystem ? {
+  $jails_file_owner = $::osfamily ? {
     default => 'root',
   }
 
-  $jails_file_group = $::operatingsystem ? {
+  $jails_file_group = $::osfamily ? {
     default => 'root',
   }
 
-  $config_file_init = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/etc/default/fail2ban',
-    default                   => '/etc/sysconfig/fail2ban',
+  $config_file_init = $::osfamily ? {
+    'Debian' => '/etc/default/fail2ban',
+    default  => '/etc/sysconfig/fail2ban',
   }
 
-  $pid_file = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/var/run/fail2ban/fail2ban.pid',
-    default                   => '/var/run/fail2ban.pid',
+  $pid_file = $::osfamily ? {
+    'Debian' => '/var/run/fail2ban/fail2ban.pid',
+    default  => '/var/run/fail2ban.pid',
   }
 
-  $data_dir = $::operatingsystem ? {
+  $data_dir = $::osfamily ? {
     default => '/etc/fail2ban',
   }
 
-  $log_dir = $::operatingsystem ? {
+  $log_dir = $::osfamily ? {
     default => '/var/log/fail2ban',
   }
 
-  $log_file = $::operatingsystem ? {
+  $log_file = $::osfamily ? {
     default => '/var/log/fail2ban/fail2ban.log',
   }
 

--- a/spec/classes/fail2ban_spec.rb
+++ b/spec/classes/fail2ban_spec.rb
@@ -26,7 +26,7 @@ describe 'fail2ban' do
   end
 
   describe 'Test jails managed throuh file - template' do
-    let(:facts) { {:operatingsystem => 'Debian' } }
+    let(:facts) { {:osfamily => 'Debian' } }
     let(:params) { {:jails_config => 'file', :jails_template => 'fail2ban/jail.local.erb', :jails => 'ssh' } }
     it { should contain_file('jail.local').without_source }
     it { should contain_file('jail.local').with_content(/ssh-iptables\]

--- a/templates/jail.local.erb
+++ b/templates/jail.local.erb
@@ -13,7 +13,11 @@ action   = iptables[name=IMAP, port=imap, protocol=tcp]
 <% unless scope.lookupvar('fail2ban::mailto').empty? -%>
            sendmail-whois[name=POP3, dest=<%= scope.lookupvar('fail2ban::mailto') %>, sender=fail2ban@<%= @fqdn %>]
 <% end -%>
+<% if @osfamily == "Debian" -%>
+logpath  = /var/log/mail.log
+<% else -%>
 logpath  = /var/log/maillog
+<% end -%>
 maxretry = 5
 
 [pop3-iptables]
@@ -23,7 +27,11 @@ action   = iptables[name=POP3, port=pop3, protocol=tcp]
 <% unless scope.lookupvar('fail2ban::mailto').empty? -%>
            sendmail-whois[name=POP3, dest=<%= scope.lookupvar('fail2ban::mailto') %>, sender=fail2ban@<%= @fqdn %>]
 <% end -%>
+<% if @osfamily == "Debian" -%>
+logpath  = /var/log/mail.log
+<% else -%>
 logpath  = /var/log/maillog
+<% end -%>
 maxretry = 5
 
 [ssh-iptables]
@@ -33,7 +41,7 @@ action   = iptables[name=SSH, port=ssh, protocol=tcp]
 <% unless scope.lookupvar('fail2ban::mailto').empty? -%>
            sendmail-whois[name=SSH, dest=<%= scope.lookupvar('fail2ban::mailto') %>, sender=fail2ban@<%= @fqdn %>]
 <% end -%>
-<% if @operatingsystem == "Debian" -%>
+<% if @osfamily == "Debian" -%>
 logpath  = /var/log/auth.log
 <% else -%>
 logpath  = /var/log/secure


### PR DESCRIPTION
The notion of operatingsystem should be abstracted for most usages by
using osfamily (which gives windows, RedHat and Debian that I know of -
not sure about MacOS).

Some specific log files were missing from the default configuration for
mail filters.