### PR TITLE
Fix incorrect bool expressions behavior due to params_lookup() behavi…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -439,7 +439,7 @@ class fail2ban (
   if $fail2ban::manage_file_source
   or $fail2ban::manage_file_content
   or $manage_file == 'absent'
-  or $fail2ban::noops {
+  or $fail2ban::noops != false {
     file { 'fail2ban.local':
       ensure  => $fail2ban::manage_file,
       path    => $fail2ban::config_file,
@@ -479,7 +479,7 @@ class fail2ban (
     if $fail2ban::manage_file_jails_source
     or $fail2ban::manage_file_jails_content
     or $manage_file == 'absent'
-    or $fail2ban::noops {
+    or $fail2ban::noops != false {
       file { 'jail.local':
         ensure  => $fail2ban::manage_file,
         path    => $fail2ban::jails_file,
@@ -498,7 +498,7 @@ class fail2ban (
   }
 
   # The whole fail2ban.configuration directory can be recursively overriden
-  if $fail2ban::source_dir {
+  if $fail2ban::source_dir != '' {
     file { 'fail2ban.dir':
       ensure  => directory,
       path    => $fail2ban::config_dir,
@@ -518,7 +518,7 @@ class fail2ban (
 
 
   ### Include custom class if $my_class is set
-  if $fail2ban::my_class {
+  if $fail2ban::my_class != '' {
     include $fail2ban::my_class
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -150,6 +150,6 @@ class fail2ban::params {
   $puppi_helper = 'standard'
   $debug = false
   $audit_only = false
-  $noops = undef
+  $noops = false
 
 }


### PR DESCRIPTION
…or and puppet 3.7+ changes

- make string comparisons with a constant value of ''. The semantics
  of empty strings has changed in the later versions of puppet. Empty
  strings are now considered always true. Since params_lookup always
  returns an empty string for undef values, this causes a reverse
  logic behavior of the entire class.

- change default value of fail2ban::noop parameter to false (not
  undef) for the same reasons as above. params_lookup would turn an
  undef to '', which in turn means true in puppet 3.7+